### PR TITLE
Update run.sh

### DIFF
--- a/supporting_files/run.sh
+++ b/supporting_files/run.sh
@@ -110,3 +110,7 @@ fi
 
 echo "Starting supervisord"
 exec supervisord -n
+
+echo "Check if custom-command script is available and start it"
+[ -d /run ] chmod -R 755 /run
+[ -x /run/execute.sh ] && /run/execute.sh >/dev/null 2>&1


### PR DESCRIPTION
As proposed in issue #112
https://github.com/mattrayner/docker-lamp/issues/112

For the user to be able to create custom commands at container startup there should be a persistend script or folder, where we can add our commands like cron startup and such

As the script resides in /run, users can easily bind mount this directory to persistent storage
If the folder or script doesn't exist, we do nothing
